### PR TITLE
Change the "autoload" attribute in composer.json from "psr-0" to "classmap"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,6 @@
         "php": ">=5.1.6"
     },
     "autoload": {
-        "psr-0": {
-            "": "src/"
-        }
+        "classmap": ["src"]
     }
 }

--- a/src/Rock/PhpWsdl/demo4.php
+++ b/src/Rock/PhpWsdl/demo4.php
@@ -6,14 +6,14 @@ ini_set('soap.wsdl_cache_enabled',0);	// Disable caching in PHP
 $PhpWsdlAutoRun=true;					// With this global variable PhpWsdl will autorun in quick mode, too
 require_once('class.phpwsdl.php');
 
-// In quick mode you can specify the class filename(s) of your webservice 
+// In quick mode you can specify the class filename(s) of your webservice
 // optional parameter, if required.
 //PhpWsdl::RunQuickMode();// -> Don't waste my time - just run!
 
-class SoapDemo{
+class SoapHelloDemo{
 	/**
 	 * Say hello to...
-	 * 
+	 *
 	 * @param string $name A name
 	 * @return string Response
 	 */


### PR DESCRIPTION
At this moment "autoload" attribute in composer.json creates a empty namespace. Unfortunately, this is not working, because require_once 'vendor/autoload.php' is not sufficient to loading PhpWsdl class. My change causes adding class "PhpWsdl" to the autoload_classmap.php file.
